### PR TITLE
Fix search bug when version data missing

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,7 +5,7 @@ import reactRefresh from 'eslint-plugin-react-refresh'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
 export default defineConfig([
-  globalIgnores(['dist']),
+  globalIgnores(['dist', 'public/strongs-greek-dictionary.js', 'public/strongs-hebrew-dictionary.js']),
   {
     files: ['**/*.{js,jsx}'],
     extends: [
@@ -24,6 +24,7 @@ export default defineConfig([
     },
     rules: {
       'no-unused-vars': ['error', { varsIgnorePattern: '^[A-Z_]' }],
+      'react-refresh/only-export-components': ['error', { allowExportNames: ['useTheme', 'ThemeContext'] }],
     },
   },
 ])

--- a/src/ThemeContext.jsx
+++ b/src/ThemeContext.jsx
@@ -1,8 +1,6 @@
-import React, { createContext, useState, useEffect, useContext } from 'react';
+import React, { createContext, useState, useEffect } from 'react';
 
-const ThemeContext = createContext();
-
-export const useTheme = () => useContext(ThemeContext);
+export const ThemeContext = createContext();
 
 export const ThemeProvider = ({ children }) => {
     const [theme, setTheme] = useState(() => {
@@ -26,3 +24,4 @@ export const ThemeProvider = ({ children }) => {
         </ThemeContext.Provider>
     );
 };
+export default ThemeProvider;

--- a/src/components/Reader.jsx
+++ b/src/components/Reader.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo, useRef } from 'react';
+import React, { useState, useMemo, useRef } from 'react';
 import { BOOKS, VERSIONS } from '../data';
 
 // --- Sub-componente para o Pop-up de Partilha ---

--- a/src/components/Search.jsx
+++ b/src/components/Search.jsx
@@ -9,7 +9,7 @@ function Search({ bibleData }) {
     const handleSearch = (e) => {
         e.preventDefault();
         if (!term) return;
-        const searchResults = bibleData[version]?.filter(v => 
+        const searchResults = (bibleData[version] || []).filter(v =>
             v.text && v.text.toLowerCase().includes(term.toLowerCase())
         );
         const formatted = searchResults.map(v => {

--- a/src/components/ThemeToggle.jsx
+++ b/src/components/ThemeToggle.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useTheme } from '../ThemeContext';
+import useTheme from '../hooks/useTheme';
 
 const SunIcon = () => <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line></svg>;
 const MoonIcon = () => <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>;

--- a/src/hooks/useTheme.js
+++ b/src/hooks/useTheme.js
@@ -1,0 +1,6 @@
+import { useContext } from 'react';
+import { ThemeContext } from '../ThemeContext';
+
+export default function useTheme() {
+  return useContext(ThemeContext);
+}


### PR DESCRIPTION
## Summary
- avoid undefined errors when searching without loaded bible version
- restructure theme hook into hooks directory
- silence lint errors for Fast Refresh and unused import

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6885341cf4ac8325ab413fba7483df98