### PR TITLE
Fix search results on missing version

### DIFF
--- a/src/components/Search.jsx
+++ b/src/components/Search.jsx
@@ -9,7 +9,7 @@ function Search({ bibleData }) {
     const handleSearch = (e) => {
         e.preventDefault();
         if (!term) return;
-        const searchResults = bibleData[version]?.filter(v => 
+        const searchResults = (bibleData[version] || []).filter(v =>
             v.text && v.text.toLowerCase().includes(term.toLowerCase())
         );
         const formatted = searchResults.map(v => {


### PR DESCRIPTION
## Summary
- ensure the search handler always uses an array

## Testing
- `npm run lint` *(fails: Fast refresh only works when a file has exports)*
- `npm run build` *(fails: Dictionary.jsx has no default export)*

------
https://chatgpt.com/codex/tasks/task_e_68855e4eee008325afec9103a5d13cc9