### PR TITLE
Fix dictionary pagination slice

### DIFF
--- a/src/components/Dictionary.jsx
+++ b/src/components/Dictionary.jsx
@@ -156,7 +156,7 @@ function Dictionary({ greekDict, hebrewDict, bibleData }) {
 
   const paginatedResults = useMemo(() => {
     const startIndex = (currentPage - 1) * ITEMS_PER_PAGE;
-    return results.slice(startIndex, startIndex, startIndex + ITEMS_PER_PAGE);
+    return results.slice(startIndex, startIndex + ITEMS_PER_PAGE);
   }, [currentPage, results]);
 
   // ... (O resto do componente Dictionary que não foi fornecido)


### PR DESCRIPTION
## Summary
- fix paginated results slice logic in `Dictionary`

## Testing
- `npm run lint` *(fails: react-refresh/only-export-components, no-unused-vars)*

------
https://chatgpt.com/codex/tasks/task_e_68855e4e1e28832591e7c3e64338b304